### PR TITLE
#25 - Temporary workaround to prevent JS errors when accessing non AE…

### DIFF
--- a/afContentScript.js
+++ b/afContentScript.js
@@ -17,13 +17,14 @@
  * limitations under the License.
  * #L%
  */
+(function() {
+  var s = document.createElement('script');
+  s.src = chrome.extension.getURL('afCustomScript.js');
+  (document.head || document.documentElement).appendChild(s);
 
-var s = document.createElement('script');
-s.src = chrome.extension.getURL('afCustomScript.js');
-(document.head || document.documentElement).appendChild(s);
-
-window.addEventListener('af-editor-loaded.afPlugin', function (e) {
-    chrome.runtime.sendMessage({url: window.location.href , action: "af-editor-loaded"}, function(response) {
-        console.log(response);
-    });
-});
+  window.addEventListener('af-editor-loaded.afPlugin', function (e) {
+      chrome.runtime.sendMessage({url: window.location.href , action: "af-editor-loaded"}, function(response) {
+          console.log(response);
+      });
+  });
+})();

--- a/afCustomScript.js
+++ b/afCustomScript.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  * #L%
  */
-
 document.addEventListener("DOMContentLoaded", function () {
     window.afPlugin = window.afPlugin || {};
     /*
@@ -34,7 +33,7 @@ document.addEventListener("DOMContentLoaded", function () {
      *   So, we set a flag (editorFrameLoaded) on window. In authorUtils, we evaluate this flag
      *   on the console and display the authoring frame.
      */
-    $(document).on("cq-editor-loaded", function () {
+    document.addEventListener("cq-editor-loaded", function () {
         window.editorFrameLoaded = true;
         window.dispatchEvent(new Event('af-editor-loaded.afPlugin'));
         addAuthoringUtils();


### PR DESCRIPTION
…M page

@gahuja1991 can you check this out and verify it works? I couldnt get much of the plugin to work on the test server, but the test page was gone so i might be missing something.

This is an interim fix for #25 to remove the JS error. It also wraps the declaration of otherwise global `var s` in anonymous scope to ensure we don't collide with other page's `s` vars.

we should figure out a way to make this JS less obtrusive since its content script (and not a background script).
